### PR TITLE
LFLT-480 Update dependencies of Leaflet stack components

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 jobs:
   build_leaflet_jwt_component:
     docker:
-      - image: cimg/openjdk:11.0.12
+      - image: cimg/openjdk:11.0
     steps:
       - checkout
       - run:

--- a/pom.xml
+++ b/pom.xml
@@ -5,13 +5,13 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>leaflet-jwt-component</artifactId>
-    <version>2.4.3</version>
+    <version>2.4.4</version>
     <packaging>jar</packaging>
 
     <parent>
         <groupId>hu.psprog.leaflet</groupId>
         <artifactId>leaflet-stack-base-bom</artifactId>
-        <version>1.0-r2110.1</version>
+        <version>2.0-r2208.1</version>
     </parent>
 
     <properties>
@@ -148,7 +148,7 @@
                 <configuration>
                     <!--suppress UnresolvedMavenProperty -->
                     <argLine>${argLine.surefire}</argLine>
-                    <forkCount>0</forkCount>
+                    <forkCount>1</forkCount>
                     <useSystemClassLoader>false</useSystemClassLoader>
                 </configuration>
             </plugin>


### PR DESCRIPTION
 - Changed CircleCI build image version
 - Updated Leaflet Stack Base BOM version to 2.0-r2208.1
 - Bumped version to 2.4.4